### PR TITLE
Fix Enqueue Handshake error

### DIFF
--- a/connection/connection.js
+++ b/connection/connection.js
@@ -1,6 +1,6 @@
 const mysql = require('mysql');
 
-const connection = mysql.createConnection({
+const pool = mysql.createPool({
   host: process.env.DB_HOST,
   port: process.env.DB_PORT,
   user: process.env.DB_USER,
@@ -8,4 +8,4 @@ const connection = mysql.createConnection({
   database: process.env.DB_NAME,
 });
 
-module.exports = connection;
+module.exports = pool;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,18 +1,17 @@
 const express = require('express');
-const connection = require('../connection/connection');
+const pool = require('../connection/connection');
 
 const router = express.Router();
 
 /* GET home page. */
 router.get('/', (req, res) => {
-  connection.connect();
-
-  connection.query('SELECT * FROM employee', (error, results) => {
-    if (error) throw error;
-    res.send(results);
+  pool.getConnection((err, connection) => {
+    connection.query('SELECT * FROM employee', (error, results) => {
+      connection.release();
+      if (error) throw error;
+      res.send(results);
+    });
   });
-
-  connection.end();
 });
 
 router.get('/whatever', (req, res) => {


### PR DESCRIPTION
Basically when using `connection.start()` and `connection.end()` I was getting the error: `Error: Cannot enqueue Handshake after invoking quit.` This was because we were terminating the connection when a request was made. This fix uses express's `pool` instead of `connection`, which will allow us to make more than 1 request to the server.

I also included an example so everyone can know how to implement it.